### PR TITLE
 OpenSSL 1.1 Fix

### DIFF
--- a/https.c
+++ b/https.c
@@ -503,13 +503,7 @@ https_open(struct https_request **reqp, const char *host)
                         _BIO_wait(req->cbio, 5000);
                 }
                 if (strncmp("HTTP/1.0 200", ctx->parse_buf, 12) != 0) {
-                        /* warning: directive output may be truncated writing up to 4095 bytes into a region of size 499 */
-                        /* ... note: ‘snprintf’ output between 14 and 4109 bytes into a destination of size 512 */
-                        #define MAX_OUTPUT  499
-                        int trunc = sizeof (ctx->errbuf);
-                        if (trunc > MAX_OUTPUT)
-                           trunc = MAX_OUTPUT;
-                        snprintf(ctx->errbuf, trunc,
+                        snprintf(ctx->errbuf, sizeof(ctx->errbuf),
                             "Proxy error: %s", ctx->parse_buf);
                         ctx->errstr = strtok(ctx->errbuf, "\r\n");
                         https_close(&req);

--- a/https.c
+++ b/https.c
@@ -91,6 +91,15 @@ _SSL_strerror(void)
         return (p ? p : strerror(errno));
 }
 
+/* OpenSSL 1.1 interface deprecation fixes */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static const unsigned char *
+ASN1_STRING_get0_data (ASN1_STRING *x)
+{
+   return (ASN1_STRING_data(x));
+}
+#endif
+
 /* Server certificate name check, logic adapted from libcurl */
 static int
 _SSL_check_server_cert(SSL *ssl, const char *hostname)
@@ -114,11 +123,7 @@ _SSL_check_server_cert(SSL *ssl, const char *hostname)
                 
                 for (i = 0; i < n && match != 1; i++) {
                         altname = sk_GENERAL_NAME_value(altnames, i);
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-                        p = (const char *) ASN1_STRING_get0_data(altname->d.ia5);
-#else
-                        p = (char *)ASN1_STRING_data(altname->d.ia5);
-#endif
+                        p = (char *)ASN1_STRING_get0_data(altname->d.ia5);
                         if (altname->type == GEN_DNS) {
                                 match = (ASN1_STRING_length(altname->d.ia5) ==
                                     strlen(p) && match_pattern(hostname, p));
@@ -137,11 +142,7 @@ _SSL_check_server_cert(SSL *ssl, const char *hostname)
                         if ((tmp = X509_NAME_ENTRY_get_data(
                                    X509_NAME_get_entry(subject, i))) != NULL &&
                             ASN1_STRING_type(tmp) == V_ASN1_UTF8STRING) {
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-                                p = (const char *)ASN1_STRING_get0_data(tmp);
-#else
-                                p = (char *)ASN1_STRING_data(tmp);
-#endif
+                                p = (char *)ASN1_STRING_get0_data(tmp);
                                 match = (ASN1_STRING_length(tmp) ==
                                     strlen(p) && match_pattern(hostname, p));
                         }
@@ -357,11 +358,7 @@ https_init(const char *useragent, const char *cafile, const char *proxy)
                         return (HTTPS_ERR_LIB);
                 }
         }
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
-        if ((ctx->ssl_ctx = SSL_CTX_new(TLS_client_method())) == NULL) {
-#else
-        if ((ctx->ssl_ctx = SSL_CTX_new(TLSv1_client_method())) == NULL) {
-#endif
+        if ((ctx->ssl_ctx = SSL_CTX_new(SSLv23_client_method())) == NULL) {
                 ctx->errstr = _SSL_strerror();
                 return (HTTPS_ERR_LIB);
         }


### PR DESCRIPTION
- `HMAC_CTX` is a pointer type in 1.1 so added conditional directives around `hmac` declaration and calls to `HMAC_xxx()` and friends where `hmac` is passed. 

- `ASN1_STRING_data()` deprecated in 1.1 so (conditionally) calling `ASN1_STRING_get0_data()`

- `TLSv1_client_method()` deprecated. Using `TLS_client_method()` which negotiates protocol version to highest version mutually supported by client and server.

**Notes**: `gcc` version 7.3.0-27ubuntu1~18.04 throws `directive output may be truncated` warning for `https.c:511` because it's worried about `ctx->parse_buf[4096]` being `snprintf()`-ed into `ctx->errbuf[512]`. The `snprintf()` call is limitied to `sizeof(ctx->errbuf)` so seems OK. It's not related to the OpenSSL fix so left it alone. 

`parson.c` has `fread()` call on line 503  which isn't checking for NULL. Should probably be wrapped with a check. Again, not related to the OpenSSL fix so ignoring it. 