### PR TITLE
Initialize array to mute cppcheck

### DIFF
--- a/test-duoapi.c
+++ b/test-duoapi.c
@@ -53,7 +53,7 @@ main(void)
 {
 	duo_t *duo;
 	duocode_t code;
-        struct duo_param params[16];
+        struct duo_param params[16] = {0};
 	char *apihost, *ikey, *skey, buf[256];
         const char *method, *uri, *body;
         int n;


### PR DESCRIPTION
Muted cppcheck on false positive

## Description
This fix is intended to mute the following cppcheck warning:
```
test-duoapi.c:43:22: warning: Uninitialized variable: params [uninitvar]
                if ((params[i].key = strsep(&p, "=")) == NULL)
                     ^
test-duoapi.c:80:[5](https://github.com/duosecurity/libduo/actions/runs/14867606827/job/41748192934#step:5:6)8: note: Calling function '_parse_line', 4th argument 'params' value is <Uninit>
                if ((n = _parse_line(buf, &method, &uri, params,
                                                         ^
test-duoapi.c:3[8](https://github.com/duosecurity/libduo/actions/runs/14867606827/job/41748192934#step:5:9):49: note: Assuming condition is false
        if ((*method = strsep(&p, " ")) == NULL ||
                                                ^
test-duoapi.c:43:22: note: Uninitialized variable: params
                if ((params[i].key = strsep(&p, "=")) == NULL)
```

## How Has This Been Tested?
CI

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
