### PR TITLE
Fix CVE-2014-0139: Prevent wildcard certificates from matching IP addresses

### DIFF
--- a/https.c
+++ b/https.c
@@ -7,6 +7,7 @@
 
 #include "config.h"
 
+#include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -106,27 +107,47 @@ _SSL_check_server_cert(SSL *ssl, const char *hostname)
 {
         X509 *cert;
         X509_NAME *subject;
-        const GENERAL_NAME *altname;
         STACK_OF(GENERAL_NAME) *altnames;
         ASN1_STRING *tmp;
         int i, n, match = -1;
-        const char *p;
+        struct in6_addr addr;
+        int hostnametype = GEN_DNS;
+        size_t addrsize = 0;
         
         if (SSL_get_verify_mode(ssl) == SSL_VERIFY_NONE ||
             (cert = SSL_get_peer_certificate(ssl)) == NULL) {
                 return (1);
         }
+
+        /* Check if hostname is an IP address */
+        if (inet_pton(AF_INET6, hostname, &addr) == 1) {
+                hostnametype = GEN_IPADD;
+                addrsize = sizeof(struct in6_addr);
+        } else if (inet_pton(AF_INET, hostname, &addr) == 1) {
+                hostnametype = GEN_IPADD;
+                addrsize = sizeof(struct in_addr);
+        }
+
         /* Check subjectAltName */
         if ((altnames = X509_get_ext_d2i(cert, NID_subject_alt_name,
                     NULL, NULL)) != NULL) {
                 n = sk_GENERAL_NAME_num(altnames);
                 
                 for (i = 0; i < n && match != 1; i++) {
-                        altname = sk_GENERAL_NAME_value(altnames, i);
-                        p = (char *)ASN1_STRING_get0_data(altname->d.ia5);
-                        if (altname->type == GEN_DNS) {
-                                match = (ASN1_STRING_length(altname->d.ia5) ==
-                                    strlen(p) && match_pattern(hostname, p));
+                        const GENERAL_NAME *altname = sk_GENERAL_NAME_value(altnames, i);
+                        if (hostnametype == altname->type) {
+                                char *altptr = (char *)ASN1_STRING_get0_data(altname->d.ia5);
+                                size_t altsize = (size_t)ASN1_STRING_length(altname->d.ia5);
+
+                                if (altname->type == GEN_DNS) {
+                                        match = (altsize == strlen(altptr) && match_pattern(hostname, altptr));
+                                } else if (altname->type == GEN_IPADD) {
+                                        if ((altsize == addrsize) && !memcmp(altptr, &addr, altsize)) {
+                                                match = 1;
+                                        } else {
+                                                match = 0;
+                                        }
+                                }
                         }
                 }
                 GENERAL_NAMES_free(altnames);
@@ -142,9 +163,15 @@ _SSL_check_server_cert(SSL *ssl, const char *hostname)
                         if ((tmp = X509_NAME_ENTRY_get_data(
                                    X509_NAME_get_entry(subject, i))) != NULL &&
                             ASN1_STRING_type(tmp) == V_ASN1_UTF8STRING) {
-                                p = (char *)ASN1_STRING_get0_data(tmp);
-                                match = (ASN1_STRING_length(tmp) ==
-                                    strlen(p) && match_pattern(hostname, p));
+                                const char *pattern = (char *)ASN1_STRING_get0_data(tmp);
+                                size_t patternsize = (size_t)ASN1_STRING_length(tmp);
+                                if (patternsize == strlen(pattern)) {
+                                        if (!strchr(pattern, '*')) {
+                                                match = strcasecmp(hostname, pattern) == 0;
+                                        } else if (hostnametype == GEN_DNS) {
+                                                match = match_pattern(hostname, pattern);
+                                        }
+                                }
                         }
                 }
         }


### PR DESCRIPTION
## Description
Fixed CVE-2014-0139 vulnerability in SSL certificate validation that incorrectly accepted wildcard patterns when validating IP addresses. Enhanced the `_SSL_check_server_cert()` function to properly distinguish between hostnames and IP addresses, preventing wildcard certificates from matching IP addresses while maintaining correct validation for legitimate hostname certificates.

## Motivation and Context
CVE-2014-0139 is a security vulnerability where SSL certificate validation incorrectly accepts wildcard IP addresses in X.509 certificates, allowing potential man-in-the-middle attacks via crafted certificates issued by legitimate Certificate Authorities. This vulnerability was previously fixed in Duo Unix and needed to be addressed in libduo to ensure consistent security across both libraries.

The fix prevents attackers from using wildcard certificates (like `*.example.com`) to impersonate services accessed via IP addresses, closing a significant security gap.

## How Has This Been Tested?
- Library compiles successfully without errors or warnings
- Verified no breaking changes to existing API
- Confirmed all CVE-2014-0139 attack vectors are mitigated

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
