### PR TITLE
Add SNI support to TLS connections

### DIFF
--- a/https.c
+++ b/https.c
@@ -554,7 +554,11 @@ https_open(struct https_request **reqp, const char *host)
         }
         req->cbio = BIO_push(sbio, req->cbio);
         BIO_get_ssl(req->cbio, &req->ssl);
-        
+
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+        SSL_set_tlsext_host_name(req->ssl, req->host);
+#endif
+
         while (BIO_do_handshake(req->cbio) <= 0) {
                 if ((n = _BIO_wait(req->cbio, 5000)) != 1) {
                         ctx->errstr = n ? _SSL_strerror() :


### PR DESCRIPTION
## Description
Add SNI (Server Name Indication) to TLS ClientHello messages by calling SSL_set_tlsext_host_name() before the TLS handshake in https.c. The call is guarded by #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME for backward compatibility with older OpenSSL versions

## Motivation and Context
libduo is the only Duo client library that does not send SNI in TLS ClientHello messages. Without SNI, servers using SNI-based routing or certificate selection cannot identify the intended virtual host, which can cause connection failures.

## How Has This Been Tested?
- Verified the project compiles without errors with OpenSSL 3.x=
-  Captured TLS traffic with tcpdump and confirmed SNI is present in ClientHello using tshark and strings:
    - With patch: Server Name: api-duo1.duo.test visible in ClientHello extension
    - Without patch: no hostname present in ClientHello

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
