### PR TITLE
Add an option to disable CA certificate pinning

### DIFF
--- a/.false_positive.txt
+++ b/.false_positive.txt
@@ -1,6 +1,6 @@
 // Suppress "Memory leak" error in `return (duo_auth_free(auth));`
-*:duo.c:479
+*:duo.c:480
 // Suppress "Memory leak" error in `return (duo_auth_free(auth));`
-*:duo.c:487
+*:duo.c:488
 // Suppress "Memory leak" error in `return (auth);`
-*:duo.c:527
+*:duo.c:528

--- a/.github/workflows/libduo-ci.yml
+++ b/.github/workflows/libduo-ci.yml
@@ -22,5 +22,11 @@ jobs:
       - name: Build
         run: ./configure && make
 
+      - name: Test CA pinning options
+        run: ./test-disable-ca-pinning
+
+      - name: Test CA pinning trust store
+        run: ./test-ca-pinning-store
+
       - name: Static analysis
         run: cppcheck --quiet --force  --suppressions-list=.false_positive.txt --error-exitcode=1 .

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@
 # Output
 test-duologin
 test-duoapi
+test-disable-ca-pinning
+test-ca-pinning-store
+test-system-store.pem
 config.*
 Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -34,7 +34,8 @@ INSTALL=@INSTALL@
 
 LIBDUO_OBJS=	duo.o http_parser.o https.o match.o parson.o urlenc.o
 
-TARGETS=	libduo.a test-duoapi test-duologin
+TARGETS=	libduo.a test-duoapi test-duologin test-disable-ca-pinning \
+		test-ca-pinning-store
 
 all: $(TARGETS)
 
@@ -53,12 +54,25 @@ test-duoapi: test-duoapi.o libduo.a
 test-duologin: test-duologin.o libduo.a
 	$(LD) -o $@ test-duologin.o $(LDFLAGS) -lduo $(LIBS)
 
+test-disable-ca-pinning: test-disable-ca-pinning.o libduo.a
+	$(LD) -o $@ test-disable-ca-pinning.o $(LDFLAGS) -lduo $(LIBS)
+
+# Includes https.c to reach its file-scope trust store, so it links the other
+# objects directly instead of libduo.a, which would duplicate those symbols.
+# The include is also why this object has to name https.c as a prerequisite -
+# nothing else here tracks that dependency.
+test-ca-pinning-store.o: https.c https.h
+
+test-ca-pinning-store: test-ca-pinning-store.o http_parser.o match.o
+	$(LD) -o $@ test-ca-pinning-store.o http_parser.o match.o \
+		$(LDFLAGS) $(LIBS)
+
 clean:
 	rm -f *.o *.a $(TARGETS) config.cache config.log
-	rm -f *.out core
+	rm -f *.out core test-system-store.pem
 
 distclean:
 	rm -f *.o *.a $(TARGETS) logintest config.cache config.log
-	rm -f *.out core *~
+	rm -f *.out core *~ test-system-store.pem
 	rm -f Makefile config.h config.status
 	rm -rf autom4te.cache

--- a/duo.c
+++ b/duo.c
@@ -67,7 +67,8 @@ HMAC_CTX_free(HMAC_CTX *ctx)
 /* Initialize Duo API handle */
 struct duo_ctx *
 duo_init(const char *apihost, const char *ikey, const char *skey,
-    const char *progname, const char *cafile, const char *proxy)
+    const char *progname, const char *cafile, int disable_ca_pinning,
+    const char *proxy)
 {
         struct duo_ctx *ctx;
         char useragent[128];
@@ -82,7 +83,7 @@ duo_init(const char *apihost, const char *ikey, const char *skey,
                 progname, CANONICAL_HOST, PACKAGE_VERSION) >= sizeof(useragent)) {
                 return (duo_close(ctx));
         }
-        if (https_init(useragent, cafile, proxy) != HTTPS_OK) {
+        if (https_init(useragent, cafile, disable_ca_pinning, proxy) != HTTPS_OK) {
                 ctx = duo_close(ctx);
         } else
         {

--- a/duo.h
+++ b/duo.h
@@ -25,9 +25,21 @@ struct duo_param {
 
 typedef struct duo_ctx duo_t;
 
-/* Initialize Duo API handle */
+/* Initialize Duo API handle.
+ *
+ * cafile selects the trusted roots: NULL uses the CA bundle built into
+ * libduo, "" skips certificate verification, and any other value is the
+ * path to a PEM bundle to trust instead.
+ *
+ * Set disable_ca_pinning to non-zero to validate against the system trust
+ * store rather than libduo's pinned CA bundle.  TLS verification is still
+ * enforced; only the set of trusted roots changes.  It cannot be combined
+ * with cafile, which must be NULL when pinning is disabled.  Pass 0 to keep
+ * CA pinning enabled, which is the default and recommended behavior.
+ */
 duo_t	   *duo_init(const char *apihost, const char *ikey, const char *skey,
-                const char *progname, const char *cafile, const char *proxy);
+                const char *progname, const char *cafile,
+                int disable_ca_pinning, const char *proxy);
 
 /* Configure a timeout on appropriate network operations.
  * Set seconds to the number of seconds to wait for network operations,

--- a/https.c
+++ b/https.c
@@ -364,19 +364,27 @@ _establish_connection(struct https_request * const req,
 }
 
 HTTPScode
-https_init(const char *useragent, const char *cafile, const char *proxy)
+https_init(const char *useragent, const char *cafile,
+           int disable_ca_pinning, const char *proxy)
 {
         X509_STORE *store;
         X509 *cert;
         BIO *bio;
         char *p;
-        
+
         if ((ctx = calloc(1, sizeof(*ctx))) == NULL) {
                 return (HTTPS_ERR_SYSTEM);
         }
         if ((ctx->useragent = strdup(useragent)) == NULL) {
                 ctx->errstr = strerror(errno);
                 return (HTTPS_ERR_SYSTEM);
+        }
+        /* Disabling CA pinning selects the system trust store, so it cannot be
+         * combined with an explicit cafile - neither a custom bundle nor the
+         * empty string that requests no verification at all. */
+        if (disable_ca_pinning && cafile != NULL) {
+                ctx->errstr = "Cannot both disable CA pinning and provide a custom CA file";
+                return (HTTPS_ERR_CLIENT);
         }
         /* Initialize SSL context */
         SSL_library_init();
@@ -401,7 +409,18 @@ https_init(const char *useragent, const char *cafile, const char *proxy)
         const long blacklist = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
         SSL_CTX_set_options(ctx->ssl_ctx, blacklist);
         /* Set up our CA cert */
-        if (cafile == NULL) {
+        if (disable_ca_pinning) {
+                /* Use the system trust store instead of our pinned bundle.
+                 * TLS verification stays enforced - only the set of trusted
+                 * roots changes. */
+                if (!SSL_CTX_set_default_verify_paths(ctx->ssl_ctx)) {
+                        SSL_CTX_free(ctx->ssl_ctx);
+                        ctx->ssl_ctx = NULL;
+                        ctx->errstr = _SSL_strerror();
+                        return (HTTPS_ERR_LIB);
+                }
+                SSL_CTX_set_verify(ctx->ssl_ctx, SSL_VERIFY_PEER, NULL);
+        } else if (cafile == NULL) {
                 /* Load default CA cert from memory */
                 if ((bio = BIO_new_mem_buf((void *)CACERT_PEM, -1)) == NULL ||
                     (store = SSL_CTX_get_cert_store(ctx->ssl_ctx)) == NULL) {
@@ -414,7 +433,7 @@ https_init(const char *useragent, const char *cafile, const char *proxy)
                 }
                 BIO_free_all(bio);
                 SSL_CTX_set_verify(ctx->ssl_ctx, SSL_VERIFY_PEER, NULL);
-        } else if (cafile[0] == '\0') {                
+        } else if (cafile[0] == '\0') {
                 /* Skip verification */
                 SSL_CTX_set_verify(ctx->ssl_ctx, SSL_VERIFY_NONE, NULL);
         } else {

--- a/https.h
+++ b/https.h
@@ -20,9 +20,14 @@ typedef enum {
         HTTPS_ERR_SERVER,	/* something the server did */
 } HTTPScode;
 
-/* Initialize HTTPS library - do this once! */
+/* Initialize HTTPS library - do this once!
+ *
+ * Set disable_ca_pinning to non-zero to verify against the system trust store
+ * instead of the pinned CA bundle.  TLS verification remains enforced.  It is
+ * mutually exclusive with cafile, which must be NULL in that case.
+ */
 HTTPScode   https_init(const char *useragent, const char *cafile,
-                       const char *proxy);
+                       int disable_ca_pinning, const char *proxy);
 
 /* Open HTTPS connection to host[:port] */
 HTTPScode   https_open(https_t **hp, const char *host);

--- a/test-ca-pinning-store.c
+++ b/test-ca-pinning-store.c
@@ -1,0 +1,263 @@
+/*
+ * test-ca-pinning-store.c
+ *
+ * Verifies which trust store https_init() actually installs.
+ *
+ * test-disable-ca-pinning.c checks the return codes of the public API, but
+ * those stay identical whether or not disable_ca_pinning is honoured - the
+ * option could be ignored entirely and every one of those tests would still
+ * pass.  This test inspects the SSL_CTX that https_init() built, so a
+ * regression that silently keeps using the pinned bundle is caught.
+ *
+ * The trust store lives in a file-scope global inside https.c, so the
+ * implementation is included directly rather than linked against libduo.a.
+ * That keeps the test hook out of the shipped library.
+ */
+
+#include "config.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "https.c"
+
+static int tests_run = 0;
+static int tests_failed = 0;
+static int tests_skipped = 0;
+
+static void
+check(const char *name, int passed, const char *detail)
+{
+        tests_run++;
+        if (passed) {
+                printf("PASS: %s\n", name);
+        } else {
+                tests_failed++;
+                printf("FAIL: %s (%s)\n", name, detail ? detail : "no detail");
+        }
+}
+
+/* X509_STORE_get0_objects() arrived in OpenSSL 1.1.0.  The library still
+ * carries shims for older releases, so rather than break the build there, the
+ * two tests that need to count certificates report themselves as skipped. */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+# define HAVE_TRUST_STORE_INSPECTION 1
+#else
+static void
+skip(const char *name, const char *why)
+{
+        tests_skipped++;
+        printf("SKIP: %s (%s)\n", name, why);
+}
+#endif
+
+#ifdef HAVE_TRUST_STORE_INSPECTION
+/* Number of certificates in the trust store https_init() just configured. */
+static int
+trust_store_size(void)
+{
+        X509_STORE *store;
+
+        if (ctx == NULL || ctx->ssl_ctx == NULL) {
+                return (-1);
+        }
+        if ((store = SSL_CTX_get_cert_store(ctx->ssl_ctx)) == NULL) {
+                return (-1);
+        }
+        return (sk_X509_OBJECT_num(X509_STORE_get0_objects(store)));
+}
+#endif
+
+/* Peer-verification mode of the context https_init() just configured. */
+static int
+verify_mode(void)
+{
+        if (ctx == NULL || ctx->ssl_ctx == NULL) {
+                return (-1);
+        }
+        return (SSL_CTX_get_verify_mode(ctx->ssl_ctx));
+}
+
+#ifdef HAVE_TRUST_STORE_INSPECTION
+/* Certificates in the bundle compiled into libduo, counted independently of
+ * https_init() so the expected value is derived rather than hardcoded. */
+static int
+pinned_bundle_size(void)
+{
+        X509 *cert;
+        BIO *bio;
+        int n = 0;
+
+        if ((bio = BIO_new_mem_buf((void *)CACERT_PEM, -1)) == NULL) {
+                return (-1);
+        }
+        while ((cert = PEM_read_bio_X509(bio, NULL, 0, NULL)) != NULL) {
+                X509_free(cert);
+                n++;
+        }
+        BIO_free_all(bio);
+        return (n);
+}
+
+/* Point OpenSSL's default verify paths at a trust store this test controls.
+ *
+ * The real system store is not usable as an expectation: a minimal container
+ * has none, so its size would be 0 - which is also what a regression that never
+ * installs the default paths produces.  Staging a file with a known number of
+ * certificates makes the two distinguishable on any host.  A certificate from
+ * the bundle is reused simply because one is already available; only the count
+ * matters, and one is not fifteen.
+ *
+ * Returns the number of certificates staged, or -1 on failure.
+ */
+static int
+stage_system_store(char *path, size_t pathlen)
+{
+        X509 *cert = NULL;
+        BIO *in = NULL, *out = NULL;
+        int fd, n = -1;
+
+        snprintf(path, pathlen, "test-system-store.pem");
+        if ((in = BIO_new_mem_buf((void *)CACERT_PEM, -1)) == NULL) {
+                return (-1);
+        }
+        if ((cert = PEM_read_bio_X509(in, NULL, 0, NULL)) == NULL) {
+                goto done;
+        }
+        if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600)) == -1) {
+                goto done;
+        }
+        if ((out = BIO_new_fd(fd, BIO_CLOSE)) == NULL) {
+                close(fd);
+                goto done;
+        }
+        if (!PEM_write_bio_X509(out, cert)) {
+                goto done;
+        }
+        BIO_free_all(out);
+        out = NULL;
+        n = 1;
+
+        /* Both must be set: SSL_CERT_DIR is pointed at a directory that does
+         * not exist so the hashed-directory lookup contributes nothing and the
+         * host's real certificates cannot skew the count. */
+        if (setenv("SSL_CERT_FILE", path, 1) != 0 ||
+            setenv("SSL_CERT_DIR", "test-system-store.d", 1) != 0) {
+                n = -1;
+        }
+done:
+        if (cert != NULL) {
+                X509_free(cert);
+        }
+        if (out != NULL) {
+                BIO_free_all(out);
+        }
+        BIO_free_all(in);
+        return (n);
+}
+#endif /* HAVE_TRUST_STORE_INSPECTION */
+
+#define STORE_SKIP_REASON "needs OpenSSL 1.1.0 or later to inspect the store"
+
+/* Pinning enabled must install exactly the bundled certificates. */
+static void
+test_pinned_store_is_the_bundle(void)
+{
+#ifndef HAVE_TRUST_STORE_INSPECTION
+        skip("pinned store holds the bundled certificates",
+            STORE_SKIP_REASON);
+#else
+        char buf[128];
+        int expected, got;
+
+        expected = pinned_bundle_size();
+        if (https_init("test-agent/1.0", NULL, 0, NULL) != HTTPS_OK) {
+                check("pinned store holds the bundled certificates", 0,
+                    "https_init failed");
+                return;
+        }
+        got = trust_store_size();
+        snprintf(buf, sizeof(buf), "expected %d bundled certs, store has %d",
+            expected, got);
+        check("pinned store holds the bundled certificates",
+            expected > 0 && got == expected, buf);
+#endif
+}
+
+/* Disabling pinning must install the default verify paths, which the staging
+ * helper above has pointed at a store of known size.  Asserting the exact count
+ * catches both a regression that keeps using the pinned bundle and one that
+ * installs no roots at all. */
+static void
+test_disabled_store_is_the_system_store(void)
+{
+#ifndef HAVE_TRUST_STORE_INSPECTION
+        skip("disabled pinning installs the system trust store",
+            STORE_SKIP_REASON);
+#else
+        char buf[128];
+        char path[64];
+        int staged, got;
+
+        if ((staged = stage_system_store(path, sizeof(path))) < 0) {
+                check("disabled pinning installs the system trust store", 0,
+                    "could not stage a system trust store");
+                return;
+        }
+        if (https_init("test-agent/1.0", NULL, 1, NULL) != HTTPS_OK) {
+                check("disabled pinning installs the system trust store", 0,
+                    "https_init failed");
+                goto done;
+        }
+        got = trust_store_size();
+        snprintf(buf, sizeof(buf), "expected %d staged certs, store has %d "
+            "(bundle has %d)", staged, got, pinned_bundle_size());
+        check("disabled pinning installs the system trust store",
+            got == staged, buf);
+done:
+        /* Undo the staging so the later tests are not left pointing at a file
+         * that is about to be deleted - they must not depend on the order they
+         * run in. */
+        unsetenv("SSL_CERT_FILE");
+        unsetenv("SSL_CERT_DIR");
+        unlink(path);
+#endif
+}
+
+/* The security invariant: disabling pinning changes which roots are trusted, it
+ * does not stop the peer certificate from being checked. */
+static void
+test_disabled_still_verifies_the_peer(void)
+{
+        char buf[128];
+        int mode;
+
+        if (https_init("test-agent/1.0", NULL, 1, NULL) != HTTPS_OK) {
+                check("disabled pinning still verifies the peer", 0,
+                    "https_init failed");
+                return;
+        }
+        mode = verify_mode();
+        snprintf(buf, sizeof(buf), "verify mode is %d, want SSL_VERIFY_PEER=%d",
+            mode, SSL_VERIFY_PEER);
+        check("disabled pinning still verifies the peer",
+            mode == SSL_VERIFY_PEER, buf);
+}
+
+int
+main(void)
+{
+        test_pinned_store_is_the_bundle();
+        test_disabled_store_is_the_system_store();
+        test_disabled_still_verifies_the_peer();
+
+        printf("\n%d/%d tests passed", tests_run - tests_failed, tests_run);
+        if (tests_skipped > 0) {
+                printf(", %d skipped", tests_skipped);
+        }
+        printf("\n");
+
+        return (tests_failed == 0) ? 0 : 1;
+}

--- a/test-disable-ca-pinning.c
+++ b/test-disable-ca-pinning.c
@@ -1,0 +1,153 @@
+/*
+ * test-disable-ca-pinning.c
+ *
+ * Tests for the disable_ca_pinning option of duo_init() and https_init().
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "duo.h"
+#include "https.h"
+
+static int tests_run = 0;
+static int tests_failed = 0;
+
+static void
+check(const char *name, int passed, const char *detail)
+{
+        tests_run++;
+        if (passed) {
+                printf("PASS: %s\n", name);
+        } else {
+                tests_failed++;
+                printf("FAIL: %s (%s)\n", name, detail ? detail : "no detail");
+        }
+}
+
+/* The message the conflict check reports.  A bad cafile path fails with the
+ * same HTTPS_ERR_CLIENT code, so tests match on the text to prove which of
+ * the two checks actually rejected the call. */
+#define CONFLICT_ERR "Cannot both disable CA pinning and provide a custom CA file"
+
+/* https_geterr() clears the stored error, so it must only be called once per
+ * https_init() - fetch it here and reuse the copy. */
+static void
+describe(char *buf, size_t buflen, HTTPScode want, HTTPScode got)
+{
+        const char *err = https_geterr();
+
+        snprintf(buf, buflen, "expected %d, got %d (%s)", want, got,
+            err != NULL ? err : "no error");
+}
+
+/* CA pinning is the default: the bundled bundle is used and init succeeds. */
+static void
+test_pinning_enabled_by_default(void)
+{
+        char buf[256];
+        HTTPScode rc;
+
+        rc = https_init("test-agent/1.0", NULL, 0, NULL);
+        describe(buf, sizeof(buf), HTTPS_OK, rc);
+        check("CA pinning enabled by default", rc == HTTPS_OK, buf);
+}
+
+/* Disabling pinning falls back to the system trust store and still succeeds. */
+static void
+test_disable_ca_pinning(void)
+{
+        char buf[256];
+        HTTPScode rc;
+
+        rc = https_init("test-agent/1.0", NULL, 1, NULL);
+        describe(buf, sizeof(buf), HTTPS_OK, rc);
+        check("disable_ca_pinning uses the system trust store",
+            rc == HTTPS_OK, buf);
+}
+
+/* With pinning left enabled, a cafile is still honoured - and a bad path is
+ * still reported, proving the new branch did not shadow the existing one. */
+static void
+test_cafile_still_honoured_when_pinning_enabled(void)
+{
+        char buf[256];
+        HTTPScode rc;
+
+        rc = https_init("test-agent/1.0", "/nonexistent/path.pem", 0, NULL);
+        describe(buf, sizeof(buf), HTTPS_ERR_CLIENT, rc);
+        check("a bad CA file path is still an error when pinning is enabled",
+            rc == HTTPS_ERR_CLIENT, buf);
+}
+
+/* The option is reached through duo_init(), which is the entry point callers
+ * actually use.  duo_init() does no network I/O, so the credentials below are
+ * never validated - only the handle setup is under test. */
+static void
+test_duo_init_accepts_the_option(void)
+{
+        duo_t *duo;
+
+        duo = duo_init("api-00000000.duosecurity.com", "ikey", "skey",
+            "test-disable-ca-pinning/" PACKAGE_VERSION, NULL, 0, NULL);
+        check("duo_init succeeds with CA pinning enabled", duo != NULL,
+            "duo_init returned NULL");
+        duo_close(duo);
+
+        duo = duo_init("api-00000000.duosecurity.com", "ikey", "skey",
+            "test-disable-ca-pinning/" PACKAGE_VERSION, NULL, 1, NULL);
+        check("duo_init succeeds with CA pinning disabled", duo != NULL,
+            "duo_init returned NULL");
+        duo_close(duo);
+}
+
+/* duo_init() must propagate the conflict rather than hand back a usable
+ * handle whose trust configuration is not what the caller asked for.
+ *
+ * Both spellings of a cafile are checked.  "" is the interesting one: it means
+ * "skip verification entirely", so letting it through would leave the caller
+ * with pinning disabled and no peer check at all - which is what disabling
+ * pinning must never turn into. */
+static void
+test_duo_init_rejects_conflicting_options(void)
+{
+        static const char *cafiles[] = { "/some/ca.pem", "" };
+        size_t i;
+
+        for (i = 0; i < sizeof(cafiles) / sizeof(cafiles[0]); i++) {
+                duo_t *duo;
+                char buf[256];
+                const char *err;
+
+                duo = duo_init("api-00000000.duosecurity.com", "ikey", "skey",
+                    "test-disable-ca-pinning/" PACKAGE_VERSION, cafiles[i], 1,
+                    NULL);
+                err = https_geterr();
+                snprintf(buf, sizeof(buf), "cafile=\"%s\", handle=%s, err=%s",
+                    cafiles[i], duo == NULL ? "NULL" : "non-NULL",
+                    err != NULL ? err : "none");
+                /* Matching the message rules out an unrelated failure - a
+                 * missing cafile would fail the same way if the conflict went
+                 * unnoticed. */
+                check("duo_init rejects disable_ca_pinning with a cafile",
+                    duo == NULL && err != NULL &&
+                    strcmp(err, CONFLICT_ERR) == 0, buf);
+                duo_close(duo);
+        }
+}
+
+int
+main(void)
+{
+        test_pinning_enabled_by_default();
+        test_disable_ca_pinning();
+        test_cafile_still_honoured_when_pinning_enabled();
+        test_duo_init_accepts_the_option();
+        test_duo_init_rejects_conflicting_options();
+
+        printf("\n%d/%d tests passed\n", tests_run - tests_failed, tests_run);
+
+        return (tests_failed == 0) ? 0 : 1;
+}

--- a/test-duoapi.c
+++ b/test-duoapi.c
@@ -66,7 +66,7 @@ main(void)
 		exit(1);
 	}
 	if ((duo = duo_init(apihost, ikey, skey,
-                    "test-duoapi/" PACKAGE_VERSION, NULL, NULL)) == NULL) {
+                    "test-duoapi/" PACKAGE_VERSION, NULL, 0, NULL)) == NULL) {
 		fprintf(stderr, "duo_init failed\n");
 		exit(1);
 	}

--- a/test-duologin.c
+++ b/test-duologin.c
@@ -37,7 +37,7 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 	if ((duo = duo_init(apihost, ikey, skey,
-                    "test-duoapi/" PACKAGE_VERSION, NULL, NULL)) == NULL) {
+                    "test-duoapi/" PACKAGE_VERSION, NULL, 0, NULL)) == NULL) {
 		fprintf(stderr, "duo_init failed\n");
 		exit(1);
 	}


### PR DESCRIPTION
## Description
- Adds a `disable_ca_pinning` parameter to `duo_init()` and `https_init()`. When non-zero, certificates are validated against the system trust store (via `SSL_CTX_set_default_verify_paths()`) instead of the CA bundle compiled into libduo
- TLS verification remains fully enforced when pinning is disabled — `SSL_VERIFY_PEER` is still set, so only the set of trusted roots changes. Hostname verification (`_SSL_check_server_cert()`) and SNI are in `https_open()`, outside the pinning branch, so they apply either way
- Default behavior is unchanged: passing `0` keeps CA pinning enabled, and the existing `cafile == NULL` branch is untouched
- Adds a mutual-exclusivity check: `disable_ca_pinning` with a non-NULL `cafile` returns `HTTPS_ERR_CLIENT` with a descriptive message, since a custom bundle and the system store select different trust anchors. This includes `cafile = ""` (which requests no verification at all), so the contradiction is reported rather than silently resolving it in favour of one option
- Documents the parameter and the `cafile` interaction in the `duo.h` and `https.h` header comments

## How Has This Been Tested?
Two new test binaries, both wired into CI:

`test-disable-ca-pinning` — public API contract (7 assertions):
- CA pinning is enabled by default and `https_init()` succeeds
- `disable_ca_pinning` succeeds and selects the system trust store
- A bad `cafile` path is still an error when pinning is enabled, confirming the new branch does not shadow the existing one
- `duo_init()` succeeds with pinning both enabled and disabled
- `duo_init()` rejects `disable_ca_pinning` combined with a `cafile`, for both a custom path and `""`, matching on the error message so an unrelated failure cannot pass

`test-ca-pinning-store` — inspects the constructed `SSL_CTX`, because the return codes are identical whether or not the option is honoured (3 assertions):
- With pinning enabled, the trust store holds exactly the certificates in the bundle, counted independently rather than hardcoded
- With pinning disabled, the store holds the default verify paths. The test stages a one-certificate PEM and points `SSL_CERT_FILE`/`SSL_CERT_DIR` at it, so the expected count is exact on any host — a minimal container has no system certificates, and asserting "> 0" there would be indistinguishable from a regression that installs no roots at all
- With pinning disabled, the verify mode is still `SSL_VERIFY_PEER`, so disabling pinning cannot silently disable TLS verification

Verified by mutation testing (each on a clean build): removing the conflict check, narrowing it to skip `cafile == ""`, and changing the disable branch from `SSL_VERIFY_PEER` to `SSL_VERIFY_NONE` are each caught by the suite.

`test-ca-pinning-store` includes `https.c` directly to reach its file-scope trust store, keeping the test hook out of the shipped library. The two assertions needing `X509_STORE_get0_objects()` (OpenSSL 1.1.0+) report as skipped on older releases rather than breaking the build.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
